### PR TITLE
(feat) halo2 public inputs

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -6,12 +6,12 @@ use num_bigint::{BigInt, BigUint, RandBigInt, Sign};
 use num_integer::Integer;
 use num_traits::{One, ToPrimitive, Zero};
 use rand::Rng;
-use std::mem;
 use std::{
     cmp::{Eq, Ord, Ordering, PartialEq},
     collections::{HashMap, HashSet},
     fmt::{self, Debug, Display, Write},
     hash::Hash,
+    mem,
     ops::{Add, Mul, Neg, Sub},
 };
 

--- a/src/plaf.rs
+++ b/src/plaf.rs
@@ -19,10 +19,10 @@ enum CellValue<F> {
 
 #[derive(Debug)]
 pub struct Witness {
-    num_rows: usize,
-    columns: Vec<ColumnWitness>,
+    pub num_rows: usize,
+    pub columns: Vec<ColumnWitness>,
     // The advice cells in the circuit, arranged as [column][row].
-    witness: Vec<Vec<Option<BigUint>>>,
+    pub witness: Vec<Vec<Option<BigUint>>>,
 }
 
 /// Adaptor struct to format the witness columns assignments as CSV
@@ -61,7 +61,7 @@ pub struct ColumnWitness {
 }
 
 impl ColumnWitness {
-    fn new(name: String, phase: usize) -> Self {
+    pub fn new(name: String, phase: usize) -> Self {
         Self {
             name,
             aliases: Vec::new(),
@@ -80,7 +80,7 @@ pub struct ColumnFixed {
 }
 
 impl ColumnFixed {
-    fn new(name: String) -> Self {
+    pub fn new(name: String) -> Self {
         Self {
             name,
             aliases: Vec::new(),
@@ -98,7 +98,7 @@ pub struct ColumnPublic {
 }
 
 impl ColumnPublic {
-    fn new(name: String) -> Self {
+    pub fn new(name: String) -> Self {
         Self {
             name,
             aliases: Vec::new(),


### PR DESCRIPTION
This PR allows to create copy constrains for public inputs in the halo2 backend.

### Contents
- `enable_equality` for all columns involved in copy constrains
- `constrain_instance` for all cells that uses public columns
- make some methods and struct vars `pub`
- chores
